### PR TITLE
Update values.yaml, uncomment preview url

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 2
 
 env:
-  preview_server_url: "https://preview.example.com"
+  #preview_server_url: "https://preview.example.com"
   run_as_preview_server: "false"
 envFrom:
   secretRefName: gtm-container-config


### PR DESCRIPTION
Unset PREVIEW_SERVER_URL. It will be set in live but has to remain unset in preview deployment.

│ Warning: PREVIEW_SERVER_URL should not be set if RUN_AS_PREVIEW_SERVER is set to true.                                                                                     │
│ ***Listening on {"address":"::","family":"IPv6","port":8080}***